### PR TITLE
Fix/display day number on commemorative days

### DIFF
--- a/web.mjs
+++ b/web.mjs
@@ -119,8 +119,10 @@ window.onload = function () {
       // If an event is found, highlight the date
       if (event) {
         date.style.backgroundColor = "lightblue";
-        // Add a tooltip with the event name
-        date.textContent = `${event.name}`;
+
+        //Create container to hold the commemorative day name
+        const commemorativeDayName = document.createElement("div");
+        commemorativeDayName.textContent = event.name;
       }
 
       //Make the outline of each cell a vidible rectangle

--- a/web.mjs
+++ b/web.mjs
@@ -87,9 +87,6 @@ window.onload = function () {
     //Make Monday start of the weekdays by modifying the indexes for days
     firstDayInMonth = (firstDayInMonth + 6) % 7;
 
-    //Clear the previous container
-    datesContainer.innerHTML = "";
-
     //align first day of month to the exact weekday it falls into
     for (let i = 0; i < firstDayInMonth; i++) {
       const emptyCell1 = document.createElement("div");

--- a/web.mjs
+++ b/web.mjs
@@ -123,10 +123,13 @@ window.onload = function () {
         //Create container to hold the commemorative day name
         const commemorativeDayName = document.createElement("div");
         commemorativeDayName.textContent = event.name;
+        date.append(commemorativeDayName);
       }
 
       //Make the outline of each cell a vidible rectangle
       date.style.border = "1px solid black";
+
+      datesContainer.append(date);
     }
 
     //Outline the empty gills into visible rectangle once a month ends

--- a/web.mjs
+++ b/web.mjs
@@ -105,8 +105,11 @@ window.onload = function () {
     //Loop through each day of the month
     for (let i = 1; i <= daysInMonth; i++) {
       const date = document.createElement("div");
-      date.textContent = i;
-      datesContainer.append(date);
+      date.style.border = "1px solid black";
+
+      const dayNum = document.createElement("div");
+      dayNum.textContent = i;
+      date.append(dayNum);
 
       // Check if there are any events for this day
       const event = events.find(

--- a/web.mjs
+++ b/web.mjs
@@ -107,6 +107,7 @@ window.onload = function () {
       const date = document.createElement("div");
       date.style.border = "1px solid black";
 
+      //Create container to hold the day number 
       const dayNum = document.createElement("div");
       dayNum.textContent = i;
       date.append(dayNum);


### PR DESCRIPTION
This PR shows update for for the logic associated with the date container to show both the commemorative day name and day number.